### PR TITLE
feat(indexeddb): add indexeddb storage option #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ export default {
 
 ### Storage Options
 
-This adapter can use either `memory` or `idb` (IndexedDB polyfill) for `PouchDB`
-storage. You may choose which storage to use by passing the `storage` option to
-the adapter:
+This adapter can use either `memory`, `idb` (IndexedDB polyfill), or `indexeddb`
+(IndexedDB BETA. See
+[distinction here](https://pouchdb.com/2020/02/12/pouchdb-7.2.0.html)) for
+`PouchDB` storage. You may choose which storage to use by passing the `storage`
+option to the adapter:
 
 ```js
 import {

--- a/deps.js
+++ b/deps.js
@@ -1,7 +1,7 @@
 export { default as crocks } from "https://cdn.skypack.dev/crocks@0.12.4";
 export * as R from "https://cdn.skypack.dev/ramda@0.28.0";
 
-export { default as PouchDB } from "https://deno.land/x/pouchdb_deno@v2.0.0-PouchDB+7.2.2/modules/pouchdb/mod.ts";
+export { default as PouchDB } from "https://deno.land/x/pouchdb_deno@2.0.0-PouchDB+7.3.0/modules/pouchdb/mod.ts";
 
 export {
   HyperErr,

--- a/meta.js
+++ b/meta.js
@@ -9,6 +9,7 @@ const metaDbName = "meta-cl1ld3td500003e68rc2f8o6x";
 
 export const PouchDbAdapterTypes = {
   idb: "idb",
+  indexeddb: "indexeddb",
   memory: "memory",
 };
 

--- a/scripts/hyper-test.sh
+++ b/scripts/hyper-test.sh
@@ -1,1 +1,3 @@
-deno test --allow-net --allow-env --no-check --import-map=https://x.nest.land/hyper-test@2.1.0/import_map.json https://x.nest.land/hyper-test@2.1.0/mod.js
+hyper_test=https://x.nest.land/hyper-test@2.1.3
+
+deno test --reload --allow-net --allow-env --no-check --import-map="$hyper_test/import_map.json" "$hyper_test/mod.js"

--- a/test/hyper.js
+++ b/test/hyper.js
@@ -1,5 +1,5 @@
-import { default as appOpine } from "https://x.nest.land/hyper-app-opine@2.0.1/mod.js";
-import { default as core } from "https://x.nest.land/hyper@3.1.0/mod.js";
+import { default as appOpine } from "https://x.nest.land/hyper-app-opine@2.1.0/mod.js";
+import { default as core } from "https://x.nest.land/hyper@3.2.2/mod.js";
 
 import myAdapter from "../mod.js";
 import PORT_NAME from "../port_name.js";
@@ -7,7 +7,10 @@ import PORT_NAME from "../port_name.js";
 const hyperConfig = {
   app: appOpine,
   adapters: [
-    { port: PORT_NAME, plugins: [myAdapter()] },
+    {
+      port: PORT_NAME,
+      plugins: [myAdapter({ dir: "./test" })],
+    },
   ],
 };
 


### PR DESCRIPTION
The new indexeddb adapter doesn't seem to solve the discrepancy between
querying couch vs pouch using an index. The issue remains open