### PR TITLE
fix: add shim to add all sort keys to selector #25

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": true
+}

--- a/README.md
+++ b/README.md
@@ -9,17 +9,6 @@
 
 ---
 
-There are some differences between `PouchDB` And `CouchDB` on how indexes are
-handled. See this
-[open issue on PouchDB](https://github.com/pouchdb/pouchdb/issues/8385):
-
-> With PouchDB, it is expected that all the indexed fields exist in the
-> `selector`, otherwise an error is returned. With CouchDB, it is expected that
-> all the indexed fields exist in the `selector` OR in the `sort`.
-
-Take this into consideration when using this adapter. An issue is open to track
-this [here](https://github.com/hyper63/hyper-adapter-pouchdb/issues/25)
-
 ## Table of Contents
 
 - [Getting Started](#getting-started)


### PR DESCRIPTION
With this change, all the tests in hyper test suite pass, where before the `query selector with sort` test was failing, so this does seem to get around the index querying issue ⚡ 

Closes #25 

---

This is a hack to get indexes to work similarly across Pouch and Couch
See https://github.com/pouchdb/pouchdb/issues/8385

Ensure each sort key is present in the selector, if not already in the selector,
by adding a check that the sort key exists on the document,
This should get around the index querying discrepancy between Pouch and Couch,
because fields must exist to be used for sort anyway.

Obviously not the most performant, but this adapter is meant for local usage anyway, so I think a justifiable tradeoff for parity between this adapter and CouchDB adapter.